### PR TITLE
Add missing mobile payment method

### DIFF
--- a/apps/capi/src/capi_handler_decoder_invoicing.erl
+++ b/apps/capi/src/capi_handler_decoder_invoicing.erl
@@ -364,7 +364,9 @@ decode_payment_method(crypto_wallet, CryptoCurrencies) ->
         <<"method">> => <<"CryptoWallet">>,
         <<"cryptoCurrency">> =>
             lists:map(fun capi_handler_decoder_utils:convert_crypto_currency_to_swag/1, CryptoCurrencies)
-    }].
+    }];
+decode_payment_method(mobile, MobileOperators) ->
+    [#{<<"method">> => <<"Mobile">>, <<"mobileOperators">> => lists:map(fun genlib:to_binary/1, MobileOperators)}].
 
 decode_tokenized_bank_cards(TokenizedBankCards) ->
     PropTokenizedBankCards = [


### PR DESCRIPTION
This fix prevents `function_clause` crash on `GetInvoicePaymentMethods` 