### PR TITLE
CAPI-412: Allow ip replacement in Invoice Access Tokens

### DIFF
--- a/apps/capi/src/capi_auth.erl
+++ b/apps/capi/src/capi_auth.erl
@@ -74,9 +74,6 @@ resolve_token_spec({invoice, InvoiceID}) ->
             {[{invoices, InvoiceID}, payments] , read },
             {[{invoices, InvoiceID}, payments] , write},
             {[payment_resources              ] , write}
-        ]),
-        <<"bin-api">> => uac_acl:from_list([
-            {[card_bins], read}
         ])
     },
     Expiration = {lifetime, ?DEFAULT_INVOICE_ACCESS_TOKEN_LIFETIME},

--- a/apps/capi/src/capi_auth.erl
+++ b/apps/capi/src/capi_auth.erl
@@ -3,10 +3,6 @@
 -export([issue_access_token/2]).
 -export([issue_access_token/3]).
 
--export([get_subject_id/1]).
--export([get_claims/1]).
--export([get_claim/2]).
--export([get_claim/3]).
 -export([get_consumer/1]).
 
 -export([get_operation_access/2]).
@@ -97,26 +93,6 @@ resolve_token_spec({customer, CustomerID}) ->
     },
     Expiration = {lifetime, ?DEFAULT_CUSTOMER_ACCESS_TOKEN_LIFETIME},
     {#{}, DomainRoles, Expiration}.
-
--spec get_subject_id(context()) -> binary().
-
-get_subject_id({_Id, {SubjectID, _ACL}, _Claims}) ->
-    SubjectID.
-
--spec get_claims(context()) -> claims().
-
-get_claims({_Id, _Subject, Claims}) ->
-    Claims.
-
--spec get_claim(binary(), context()) -> term().
-
-get_claim(ClaimName, {_Id, _Subject, Claims}) ->
-    maps:get(ClaimName, Claims).
-
--spec get_claim(binary(), context(), term()) -> term().
-
-get_claim(ClaimName, {_Id, _Subject, Claims}, Default) ->
-    maps:get(ClaimName, Claims, Default).
 
 %%
 

--- a/apps/capi/src/capi_handler.erl
+++ b/apps/capi/src/capi_handler.erl
@@ -158,10 +158,10 @@ create_woody_context(RpcID, AuthContext) ->
 
 collect_user_identity(AuthContext) ->
     genlib_map:compact(#{
-        id       => capi_auth:get_subject_id(AuthContext),
+        id       => uac_authorizer_jwt:get_subject_id(AuthContext),
         realm    => ?REALM,
-        email    => capi_auth:get_claim(<<"email">>, AuthContext, undefined),
-        username => capi_auth:get_claim(<<"name">> , AuthContext, undefined)
+        email    => uac_authorizer_jwt:get_claim(<<"email">>, AuthContext, undefined),
+        username => uac_authorizer_jwt:get_claim(<<"name">> , AuthContext, undefined)
     }).
 
 attach_deadline(#{'X-Request-Deadline' := undefined}, Context) ->

--- a/apps/capi/src/capi_handler_decoder_invoicing.erl
+++ b/apps/capi/src/capi_handler_decoder_invoicing.erl
@@ -209,7 +209,7 @@ decode_payment_status({Status, StatusInfo}, Context) ->
 decode_payment_operation_failure({operation_timeout, _}, _) ->
     payment_error(<<"timeout">>);
 decode_payment_operation_failure({failure, Failure}, Context) ->
-    case capi_auth:get_consumer(capi_auth:get_claims(capi_handler_utils:get_auth_context(Context))) of
+    case capi_auth:get_consumer(uac_authorizer_jwt:get_claims(capi_handler_utils:get_auth_context(Context))) of
         client ->
             payment_error(payproc_errors:match('PaymentFailure', Failure, fun payment_error_client_maping/1));
         merchant ->

--- a/apps/capi/src/capi_handler_invoices.erl
+++ b/apps/capi/src/capi_handler_invoices.erl
@@ -43,11 +43,13 @@ process_request('CreateInvoice' = OperationID, Req, Context) ->
 
 process_request('CreateInvoiceAccessToken', Req, Context) ->
     InvoiceID = maps:get(invoiceID, Req),
+    ExtraProperties = capi_handler_utils:get_extra_properties(Context),
     case capi_handler_utils:get_invoice_by_id(InvoiceID, Context) of
         {ok, #'payproc_Invoice'{}} ->
             Response =  capi_handler_utils:issue_access_token(
                 capi_handler_utils:get_party_id(Context),
-                {invoice, InvoiceID}
+                {invoice, InvoiceID},
+                ExtraProperties
             ),
             {ok, {201, #{}, Response}};
         {exception, Exception} ->

--- a/apps/capi/src/capi_handler_utils.erl
+++ b/apps/capi/src/capi_handler_utils.erl
@@ -120,7 +120,7 @@ service_call({ServiceName, Function, Args}, #{woody_context := WoodyContext}) ->
 get_party_params(Context) ->
     #payproc_PartyParams{
         contact_info = #domain_PartyContactInfo{
-            email = capi_auth:get_claim(<<"email">>, get_auth_context(Context))
+            email = uac_authorizer_jwt:get_claim(<<"email">>, get_auth_context(Context))
         }
     }.
 
@@ -140,13 +140,13 @@ get_user_info(Context) ->
     binary().
 
 get_party_id(Context) ->
-    capi_auth:get_subject_id(get_auth_context(Context)).
+    uac_authorizer_jwt:get_subject_id(get_auth_context(Context)).
 
 -spec get_extra_properties(processing_context()) ->
     map().
 
 get_extra_properties(Context) ->
-    capi_auth:get_claims(get_auth_context(Context)).
+    uac_authorizer_jwt:get_claims(get_auth_context(Context)).
 %% Common functions
 
 -spec get_my_party(processing_context()) ->

--- a/rebar.lock
+++ b/rebar.lock
@@ -108,7 +108,7 @@
   1},
  {<<"uac">>,
   {git,"git@github.com:rbkmoney/erlang_uac.git",
-       {ref,"a6b71a9a8299a203d211c23b9c7895e26abb57f5"}},
+       {ref,"6bd5b5dfc62b8c2673e7360eb99f9092ae3c6e12"}},
   0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},2},
  {<<"woody">>,


### PR DESCRIPTION
[По аналогии](https://github.com/rbkmoney/erlang_capi/blob/v2/apps/capi/src/capi_handler_invoices.erl#L18) с созданием токена в `CreateInvoice` прокидываю дополнительные клеймы при создании токена в `CreateInvoiceAccessToken`