### PR TITLE
CAPI-412: Choose which claims will be included into InvAccToken

### DIFF
--- a/apps/capi/src/capi_auth.erl
+++ b/apps/capi/src/capi_auth.erl
@@ -9,6 +9,8 @@
 
 -export([get_access_config/0]).
 
+-export([get_extra_properties/0]).
+
 -type context () :: uac:context().
 -type claims  () :: uac:claims().
 -type consumer() :: client | merchant | provider.
@@ -279,6 +281,14 @@ get_resource_hierarchy() ->
         payouts             => #{},
         card_bins           => #{}
     }.
+
+-spec get_extra_properties() -> [binary()].
+
+% Which claims are gonna make it to InvoiceAccessTokens
+get_extra_properties() ->
+    [
+        <<"ip_replacement_allowed">>
+    ].
 
 -spec get_consumer(claims()) ->
     consumer().

--- a/apps/capi/src/capi_handler_utils.erl
+++ b/apps/capi/src/capi_handler_utils.erl
@@ -147,7 +147,7 @@ get_party_id(Context) ->
 
 get_extra_properties(Context) ->
     Claims = uac_authorizer_jwt:get_claims(get_auth_context(Context)),
-    maps:with(capi_utils:extra_properties(), Claims).
+    maps:with(capi_auth:get_extra_properties(), Claims).
 
 %% Common functions
 

--- a/apps/capi/src/capi_handler_utils.erl
+++ b/apps/capi/src/capi_handler_utils.erl
@@ -146,7 +146,9 @@ get_party_id(Context) ->
     map().
 
 get_extra_properties(Context) ->
-    uac_authorizer_jwt:get_claims(get_auth_context(Context)).
+    Claims = uac_authorizer_jwt:get_claims(get_auth_context(Context)),
+    maps:with(capi_utils:extra_properties(), Claims).
+
 %% Common functions
 
 -spec get_my_party(processing_context()) ->


### PR DESCRIPTION
В текущем виде в `InvoiceAccessToken` попадает много мусорной информации, если точнее, то туда мержатся все клеймы из токена клиента. Это приводит к ненужному увеличению размера токена. По-идее мы четко знаем то, какие клеймы должны попадать в эти токены, причём их список редко изменяется. Так что его можно просто захардкодить.
